### PR TITLE
Fix wrong parameter

### DIFF
--- a/addon/TelemetryRappor.jsm
+++ b/addon/TelemetryRappor.jsm
@@ -238,7 +238,7 @@ function getInstantRandomizedResponse(prr, p, q) {
   // Get a array whose bits are 1 with probability p.
   let pGen = getBloomBits(p, filterSize);
   // Get a array whose bits are 1 with probability q.
-  let qGen = getBloomBits(p, filterSize);
+  let qGen = getBloomBits(q, filterSize);
   // Generate the IRR.
   return mask(prr, pGen, qGen);
 }


### PR DESCRIPTION
`getBloomBits` received a wrong parameter when generating `qGen`.